### PR TITLE
Retrieve map of strings directly from persitentRepository when the return map of getStrings() from StringLoader is empty. 

### DIFF
--- a/restring/src/main/java/com/b3nedikt/restring/StringsLoaderTask.kt
+++ b/restring/src/main/java/com/b3nedikt/restring/StringsLoaderTask.kt
@@ -1,6 +1,7 @@
 package com.b3nedikt.restring
 
 import android.os.AsyncTask
+import com.b3nedikt.restring.repository.CachedStringRepository
 import java.util.*
 
 /**
@@ -40,8 +41,17 @@ internal class StringsLoaderTask(private val stringsLoader: Restring.StringsLoad
 
         for (lang in languages) {
             val keyValues = stringsLoader.getStrings(lang)
+
             if (keyValues.isNotEmpty()) {
                 localizedStrings[lang] = keyValues
+            }else{
+                if(stringRepository is CachedStringRepository)
+                {
+                    val keyValues=stringRepository.persistentRepository.getStrings(lang)
+                    if(keyValues.isNotEmpty())
+                        localizedStrings[lang] = keyValues
+                }
+
             }
         }
         return localizedStrings

--- a/restring/src/main/java/com/b3nedikt/restring/repository/CachedStringRepository.kt
+++ b/restring/src/main/java/com/b3nedikt/restring/repository/CachedStringRepository.kt
@@ -4,7 +4,7 @@ import com.b3nedikt.restring.StringRepository
 import java.util.*
 
 class CachedStringRepository(private val cacheRepository: StringRepository,
-                             private val persistentRepository: StringRepository
+                              val persistentRepository: StringRepository
 ) : StringRepository {
 
     override var supportedLocales: Set<Locale> = setOf()


### PR DESCRIPTION
- retrieve map of Strings from persistentRepository when map from StringLoader is empty
- made persistentRepository constructor parameter public.
This becomes handy when we're retrieving content from api and we dont want to do it every time.